### PR TITLE
Constellation names on map

### DIFF
--- a/src/main/kotlin/dev/nohus/rift/map/MapWindow.kt
+++ b/src/main/kotlin/dev/nohus/rift/map/MapWindow.kt
@@ -680,6 +680,11 @@ private fun SystemInfoBoxesLayer(
         } else {
             null
         }
+        val constellationName = if(state.settings.showConstellation) {
+            state.cluster.constellations.first { it.id == system.constellationId}.name
+        } else {
+            null
+        }
 
         val isZoomEnough = (state.settings.isAlwaysShowingSystems || mapScale <= (0.9f / LocalDensity.current.density))
         val isShowingSystemInfoBox = (state.mapType is RegionMap && isZoomEnough) ||
@@ -690,6 +695,7 @@ private fun SystemInfoBoxesLayer(
             SystemInfoBox(
                 system = system,
                 regionName = regionName,
+                constellationName = constellationName,
                 isHighlightedOrHovered = isHighlightedOrHovered,
                 intel = state.mapState.intel[system.id],
                 hasIntelPopup = hasIntelPopup,

--- a/src/main/kotlin/dev/nohus/rift/map/SystemInfoBox.kt
+++ b/src/main/kotlin/dev/nohus/rift/map/SystemInfoBox.kt
@@ -90,6 +90,7 @@ import java.time.Instant
 fun SystemInfoBox(
     system: MapSolarSystem,
     regionName: String?,
+    constellationName: String?,
     isHighlightedOrHovered: Boolean,
     intel: List<Dated<SystemEntity>>?,
     hasIntelPopup: Boolean,
@@ -153,6 +154,15 @@ fun SystemInfoBox(
                     if (regionName != null) {
                         Text(
                             text = regionName,
+                            style = RiftTheme.typography.captionSecondary,
+                            modifier = Modifier
+                                .pointerHoverIcon(PointerIcon(Cursors.pointerInteractive))
+                                .onClick { onRegionClick() },
+                        )
+                    }
+                    if (constellationName != null) {
+                        Text(
+                            text = constellationName,
                             style = RiftTheme.typography.captionSecondary,
                             modifier = Modifier
                                 .pointerHoverIcon(PointerIcon(Cursors.pointerInteractive))

--- a/src/main/kotlin/dev/nohus/rift/map/settings/MapSettingsViewModel.kt
+++ b/src/main/kotlin/dev/nohus/rift/map/settings/MapSettingsViewModel.kt
@@ -32,6 +32,7 @@ class MapSettingsViewModel(
         val jumpBridgeNetworkUrl: String?,
         val jumpBridgeSearchState: JumpBridgeSearchState,
         val isJumpBridgeSearchDialogShown: Boolean,
+        val showConstellation: Boolean,
     )
 
     sealed interface JumpBridgeNetworkState {
@@ -62,6 +63,7 @@ class MapSettingsViewModel(
             jumpBridgeNetworkUrl = configurationPackRepository.getJumpBridgeNetworkUrl(),
             jumpBridgeSearchState = JumpBridgeSearchState.NotSearched,
             isJumpBridgeSearchDialogShown = false,
+            showConstellation = false,
         ),
     )
     val state = _state.asStateFlow()
@@ -87,6 +89,10 @@ class MapSettingsViewModel(
                 }
             }
         }
+    }
+
+    fun onShowConstellationChange(enabled: Boolean) {
+        settings.intelMap = settings.intelMap.copy(showConstellation = enabled)
     }
 
     fun onIntelPopupTimeoutSecondsChange(seconds: Int) {

--- a/src/main/kotlin/dev/nohus/rift/map/settings/MapSettingsWindow.kt
+++ b/src/main/kotlin/dev/nohus/rift/map/settings/MapSettingsWindow.kt
@@ -73,6 +73,7 @@ fun MapSettingsWindow(
             onJumpBridgeImportClick = viewModel::onJumpBridgeImportClick,
             onJumpBridgeSearchClick = viewModel::onJumpBridgeSearchClick,
             onJumpBridgeSearchImportClick = viewModel::onJumpBridgeSearchImportClick,
+            onShowConstellationChange = viewModel::onShowConstellationChange,
         )
 
         if (state.isJumpBridgeSearchDialogShown) {
@@ -128,6 +129,7 @@ private fun MapSettingsWindowContent(
     onIsCharacterFollowingChange: (Boolean) -> Unit,
     onIsScrollZoomInvertedChange: (Boolean) -> Unit,
     onIsAlwaysShowingSystemsChange: (Boolean) -> Unit,
+    onShowConstellationChange: (Boolean) -> Unit,
     onIsUsingRiftAutopilotRouteChange: (Boolean) -> Unit,
     onIsJumpBridgeNetworkShownChange: (Boolean) -> Unit,
     onJumpBridgeNetworkOpacityChange: (Int) -> Unit,
@@ -162,6 +164,12 @@ private fun MapSettingsWindowContent(
                 tooltip = "System labels won't hide when zooming out",
                 isChecked = intelMap.isAlwaysShowingSystems,
                 onCheckedChange = { onIsAlwaysShowingSystemsChange(it) },
+            )
+            RiftCheckboxWithLabel(
+                label = "Show constellation",
+                tooltip = "System infoboxes will show constellation",
+                isChecked = intelMap.showConstellation,
+                onCheckedChange = { onShowConstellationChange(it) },
             )
             Text(
                 text = buildAnnotatedString {

--- a/src/main/kotlin/dev/nohus/rift/settings/persistence/SettingsModel.kt
+++ b/src/main/kotlin/dev/nohus/rift/settings/persistence/SettingsModel.kt
@@ -104,6 +104,7 @@ data class IntelMap(
     val jumpBridgeNetworkOpacity: Int = 100,
     val openedLayoutId: Int? = null,
     val isAlwaysShowingSystems: Boolean = false,
+    val showConstellation: Boolean = false,
 )
 
 @Serializable


### PR DESCRIPTION
I added a setting to allow users to enable showing the constellation names on the system's infobox. Main usage for this would be to see which system belong to which constellation for usage in the agency windows to search for certain types of content